### PR TITLE
Use setImmediate for callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ function overriddenSocketSend(
     delete intercepts[host];
 
     if (callback) {
-      callback(null, length);
+      setImmediate(() => callback(null, length));
     }
 
     return;


### PR DESCRIPTION
Without setImmediate, the callback() executes before the `send` function
finishes executing. This leads to weird race conditions because the
callbacks are supposed to execute in the next phase of the event-loop
(see [Node.JS
Docs](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/)).

This change invokes the callback in setImmediate.